### PR TITLE
Improve cases of volume being unavailable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,6 +5,10 @@ History
 0.2.3 (2018-MM-DD)
 ------------------
 
+- Bug fixes:
+
+  - Detach a volume when it's unavailable.
+
 - Features:
 
   - Provide better message when device is not available.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,13 @@
 History
 =======
 
+0.2.3 (2018-MM-DD)
+------------------
+
+- Features:
+
+  - Provide better message when device is not available.
+
 0.2.2 (2018-07-24)
 ------------------
 

--- a/cinderlib/objects.py
+++ b/cinderlib/objects.py
@@ -726,6 +726,7 @@ class Connection(Object, LazyVolumeAttr):
             LOG.exception(error_msg)
 
         if error_msg:
+            self.detach(force=True, ignore_errors=True)
             raise cinder_exception.DeviceUnavailable(
                 path=self.path, attach_info=self._ovo.connection_information,
                 reason=error_msg)


### PR DESCRIPTION
When a volume is unavailable sometimes is hard to figure out that the problem is a missing package on the hos (ie: ceph-common).

We are also leaving devices behind when a volume is unavailable because we don't detach it.

This PR improves the exception message and detaches the volume when the device is unavailable.