### PR TITLE
Add driver_options

### DIFF
--- a/cinderlib/__init__.py
+++ b/cinderlib/__init__.py
@@ -36,6 +36,7 @@ dumps = serialization.dumps
 
 setup = cinderlib.setup
 Backend = cinderlib.Backend
+driver_options = cinderlib.Backend.driver_options
 
 get_connector_properties = objects.brick_connector.get_connector_properties
 list_supported_drivers = cinderlib.Backend.list_supported_drivers

--- a/cinderlib/cinderlib.py
+++ b/cinderlib/cinderlib.py
@@ -101,6 +101,11 @@ class Backend(object):
 
         self._pool_names = tuple(pool['pool_name'] for pool in stats['pools'])
 
+    @staticmethod
+    def driver_options(volume_driver):
+        """Return the driver specific configuration options."""
+        return importutils.import_class(volume_driver).get_driver_options()
+
     @property
     def pool_names(self):
         return self._pool_names


### PR DESCRIPTION
This patch adds a new cinderlib base method to fetch a specific driver's
driver options.

This depends on a cinder patch here:
https://review.openstack.org/635255